### PR TITLE
Fix wrong "What is Counterparty?" link in footer navbar

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,7 @@
 const currentYear = new Date().getFullYear();
 
 const aboutLinks = [
-  { label: "What is Counterparty?", href: "/#whatiscounterparty" },
+  { label: "What is Counterparty?", href: "https://docs.counterparty.io/docs/basics/what-is-counterparty/" },
   { label: "Wallets", href: "/#wallets" },
   { label: "Explorers", href: "/#explorers" },
   { label: "Marketplaces", href: "/#marketplaces" },


### PR DESCRIPTION
The link currently points to the old anchor #whatiscounterparty on the main site. 

Updated it to the correct docs page: https://docs.counterparty.io/docs/basics/what-is-counterparty/