### PR TITLE
Update Footer.astro

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,7 +19,8 @@ const resourceLinks = [
 const communityLinks = [
   { label: "Twitter", href: "https://twitter.com/CounterpartyXCP" },
   { label: "Telegram", href: "https://t.me/+hgJVFwSbZUkxYjgx" },
-  { label: "Forum", href: "https://forums.counterparty.io/" },
+  { label: "Discussions", href: "https://github.com/CounterpartyXCP/CIPs/discussions" },
+  { label: "Archived Forum", href: "https://forums.counterparty.io/" },
 ];
 ---
 


### PR DESCRIPTION
differentiate where current 'discussions' for new users should go and differentiate through titles only for the 'archived forums' of the past in footer on website (which is a good historical resource for new and old users still)